### PR TITLE
Fix incorrect latest entry time for saved checkpoints

### DIFF
--- a/src/custom/logfile_checkpoints.rs
+++ b/src/custom/logfile_checkpoints.rs
@@ -26,6 +26,7 @@ pub fn save_checkpoint(monitor: &mut LogMonitor) -> Result<String, Error> {
 
     let mut checkpoint = LogfileCheckpoint::new();
     monitor.to_checkpoint(&mut checkpoint);
+    checkpoint.latest_entry_time = last_entry_time;
 
     let checkpoint_string = serde_json::to_string(&checkpoint).unwrap();
     match fs::write(checkpoint_tmp_path.clone(), checkpoint_string) {


### PR DESCRIPTION
Checkpoints were being saved with the monitor's latest checkpoint time, but with up to date metrics. Log lines that were already accounted for in the metrics could be processed again. 

Fixes #22 